### PR TITLE
Fixed transparent area behind file manager.

### DIFF
--- a/source/PListItem.h
+++ b/source/PListItem.h
@@ -5,6 +5,7 @@
 #include <View.h>
 #include <Entry.h>
 #include <stdlib.h>
+#include <cstring>
 
 class PListItem : public BListItem 
 {

--- a/source/WindowPeek.cpp
+++ b/source/WindowPeek.cpp
@@ -357,8 +357,8 @@ WindowPeek::WindowPeek( BRect R, char* name , Setup* s, Language *w)
 
   // ok
   
-  alles->SetViewColor( mainMenu->ViewColor() );
-  filePane->SetViewColor( mainMenu->ViewColor() );
+  alles->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+  filePane->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
   imagePane->EmptyList();
 
   alles->AddChild( new BScrollView("imagePaneScrollView", imagePane, B_FOLLOW_ALL_SIDES, B_FRAME_EVENTS, true, true, B_NO_BORDER) );


### PR DESCRIPTION
I've fixed issue #2 
Also, I've fixed `PListItem.h` by adding a missing <cstring> header, so that the file can build.