### PR TITLE
Filter out incompatible files from the file list/explorer.

### DIFF
--- a/source/ViewFile.cpp
+++ b/source/ViewFile.cpp
@@ -336,6 +336,20 @@ int32 ViewFile::BuildListing() {
     if (tempEntry.IsDirectory()) isDir = true;
                             else isDir = false;
 
+    if (!isDir) {
+	BNode tempNode( &tempEntry );
+	BNodeInfo tempNodeInfo( &tempNode );
+	char mimeType[B_MIME_TYPE_LENGTH];
+
+	if (tempNodeInfo.GetType(mimeType) != B_OK)
+		continue;
+
+	strtok(mimeType, "/");
+
+	if (strcmp(mimeType, "image") != 0)
+		continue;
+    }
+
     newPList = new PListItem( tempRef, isDir );                            
 
     if ( isDir ) newList->AddItem( (void*) newPList  );


### PR DESCRIPTION
I made it filter out incompatible files by checking if the MIME type starts with `image/`. Let me know if there's anything that needs to be fixed/changed.

Fixes #6 